### PR TITLE
Supporting submodule of IoTDB, and keep consistent with the parent repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,13 @@ e2e_test:
 e2e_test_clean:
 	rm -rf /tmp/iotdb docker-context
 	docker-compose -f test/e2e/docker-compose.yml down
+
+#only used for project structure that the iotdb main project is in the parent folder of this project.
+e2e_test_for_parent_git_repo:
+    mkdir -p docker-context/iotdb
+    unzip -o -q server/target/iotdb-server-*.zip -d docker-context/iotdb
+    docker-compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --remove-orphans
+
+e2e_test_clean_for_parent_git_repo:
+	rm -rf docker-context
+	docker-compose -f test/e2e/docker-compose.yml down

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ e2e_test_clean:
 #only used for project structure that the iotdb main project is in the parent folder of this project.
 e2e_test_for_parent_git_repo:
 	mkdir -p docker-context/iotdb
-	unzip -o -q server/target/iotdb-server-*.zip -d docker-context/iotdb
+	unzip -o -q ../server/target/iotdb-server-*.zip -d docker-context/iotdb
 	docker-compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --remove-orphans
 
 e2e_test_clean_for_parent_git_repo:

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,9 @@ e2e_test_clean:
 
 #only used for project structure that the iotdb main project is in the parent folder of this project.
 e2e_test_for_parent_git_repo:
-    mkdir -p docker-context/iotdb
-    unzip -o -q server/target/iotdb-server-*.zip -d docker-context/iotdb
-    docker-compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --remove-orphans
+	mkdir -p docker-context/iotdb
+	unzip -o -q server/target/iotdb-server-*.zip -d docker-context/iotdb
+	docker-compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --remove-orphans
 
 e2e_test_clean_for_parent_git_repo:
 	rm -rf docker-context

--- a/Makefile
+++ b/Makefile
@@ -49,20 +49,20 @@ test:
 
 e2e_test:
 	sh -c "cd /tmp/ && rm -rf iotdb && git clone https://github.com/apache/iotdb.git && cd iotdb && mvn -Dmaven.test.skip=true package -am -pl server"
-	mkdir -p docker-context/iotdb
-	unzip -o -q /tmp/iotdb/server/target/iotdb-server-*.zip -d docker-context/iotdb
+	mkdir -p target/iotdb
+	unzip -o -q /tmp/iotdb/server/target/iotdb-server-*.zip -d target/iotdb
 	docker-compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --remove-orphans
 
 e2e_test_clean:
-	rm -rf /tmp/iotdb docker-context
+	rm -rf /tmp/iotdb target
 	docker-compose -f test/e2e/docker-compose.yml down
 
 #only used for project structure that the iotdb main project is in the parent folder of this project.
 e2e_test_for_parent_git_repo:
-	mkdir -p docker-context/iotdb
-	unzip -o -q ../server/target/iotdb-server-*.zip -d docker-context/iotdb
+	mkdir -p target/iotdb
+	unzip -o -q ../server/target/iotdb-server-*.zip -d target/iotdb
 	docker-compose -f test/e2e/docker-compose.yml up --build --abort-on-container-exit --remove-orphans
 
 e2e_test_clean_for_parent_git_repo:
-	rm -rf docker-context
+	rm -rf target
 	docker-compose -f test/e2e/docker-compose.yml down

--- a/test/e2e/Dockerfile.iotdb-server
+++ b/test/e2e/Dockerfile.iotdb-server
@@ -21,7 +21,7 @@ FROM openjdk:11-jre-slim
 
 RUN apt update \
   && apt install -y procps && apt clean
-ADD docker-context /usr/local
+ADD target /usr/local
 WORKDIR /usr/local/iotdb
 EXPOSE 6667
 CMD [ "/usr/local/iotdb/sbin/start-server.sh" ]


### PR DESCRIPTION
1. add two new targets in makefile
2. move docker-context to target to keep consistent with iotdb' repo