### PR TITLE
Update README_ZH.md, deleted the redundant title "如何编译"

### DIFF
--- a/README_ZH.md
+++ b/README_ZH.md
@@ -29,8 +29,6 @@
 Apache IoTDB website: https://iotdb.apache.org
 Apache IoTDB Github: https://github.com/apache/iotdb
 
-## 如何编译
-
 ## 环境准备
 
     golang >= 1.13


### PR DESCRIPTION
删掉了中文readme中的“如何编译”这一冗余标题