### PR TITLE
Update README, add Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,19 @@ go run session_example.go
 * make >= 3.0
 * curl >= 7.1.1
 * thrift 0.15.0
+
+## Troubleshooting
+
+### Thrift version compatibility issues
+
+In the branch `rel/0.13.0` and earlier versions, the version of apache/thrift is `v0.14.1`.
+In the latest version, apache/thrift has been upgraded to `v0.15.0`.
+
+The two versions are not compatible on some interfaces. Using mismatched version will cause compilation errors.
+
+The interfaces changed in the two versions are as follows:
+
+1. `NewTSocketConf`. This function returns two values in the version `v0.14.1` and only one value in the version `v0.15.0`.
+2. `NewTFramedTransport` has been deprecated, use `NewTFramedTransportConf` instead.
+
+For more details, please take a look at this PR: [update thrift to 0.15.0 to fit IoTDB 0.13.0](https://github.com/apache/iotdb-client-go/pull/41)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ go run session_example.go
 
 ### Thrift version compatibility issues
 
-In the branch `rel/0.13.0` and earlier versions, the version of apache/thrift is `v0.14.1`.
+In the branch `rel/0.13` and earlier versions, the version of apache/thrift is `v0.14.1`.
 In the latest version, apache/thrift has been upgraded to `v0.15.0`.
 
 The two versions are not compatible on some interfaces. Using mismatched version will cause compilation errors.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -89,3 +89,18 @@ go run session_example.go
 * make   >= 3.0
 * curl   >= 7.1.1
 * thrift 0.15.0
+
+## 疑难解答
+
+### thrift 版本兼容性问题
+
+分支`rel/0.13.0`以及更早前的版本中，apache/thrift的版本为`v0.14.1`。
+在更新的版本中，apache/thrift已经升级为`v0.15.0`。
+这两个版本在一些接口上并不兼容，使用不对应的版本，会导致编译报错。
+
+两个版本中有改动的接口如下：
+
+1. `NewTSocketConf`。该接口在`v0.14.1`版本中返回2个值，在`v0.15.0`版本中返回1个值。
+2. `NewTFramedTransport`已弃用，改用为`NewTFramedTransportConf`。
+
+更多相关的内容可以参考这个PR：[update thrift to 0.15.0 to fit IoTDB 0.13.0](https://github.com/apache/iotdb-client-go/pull/41)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -94,7 +94,7 @@ go run session_example.go
 
 ### thrift 版本兼容性问题
 
-分支`rel/0.13.0`以及更早前的版本中，apache/thrift的版本为`v0.14.1`。
+分支`rel/0.13`以及更早前的版本中，apache/thrift的版本为`v0.14.1`。
 在更新的版本中，apache/thrift已经升级为`v0.15.0`。
 这两个版本在一些接口上并不兼容，使用不对应的版本，会导致编译报错。
 


### PR DESCRIPTION
Update README, add Troubleshooting section.
Describes the possible causes of the thrift compatibility problem and some using tips.