### PR TITLE
fix 'connectionTimeoutInMs' mismatch with actual usage in branch 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,12 @@ The interfaces changed in the two versions are as follows:
 2. `NewTFramedTransport` has been deprecated, use `NewTFramedTransportConf` instead.
 
 For more details, please take a look at this PR: [update thrift to 0.15.0 to fit IoTDB 0.13.0](https://github.com/apache/iotdb-client-go/pull/41)
+
+### Parameter name mismatch with actual usage in function 'Open'
+
+The implementation of the function ```client/session.go/Open()``` is mismatched with the description.
+The parameter `connectionTimeoutInMs` represents connection timeout in milliseconds.
+However, in the older version, this function did not implement correctly, regarding it as nanosecond instead.
+The bug is now fixed.
+Positive value of this parameter means connection timeout in milliseconds.
+Set 0 for no timeout.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -104,3 +104,9 @@ go run session_example.go
 2. `NewTFramedTransport`已弃用，改用为`NewTFramedTransportConf`。
 
 更多相关的内容可以参考这个PR：[update thrift to 0.15.0 to fit IoTDB 0.13.0](https://github.com/apache/iotdb-client-go/pull/41)
+
+### Open函数参数名称与实际功能不匹配的问题
+
+函数```client/session.go/Open()```有一个参数`connectionTimeoutInMs`，表示了以毫秒为单位的连接超时时间。
+但旧版本中，该函数在实现时并未正确进行单位转换，而是将其看作了纳秒。现在该问题已修复。
+当该参数为0时，表示不设置超时时间；当设置为正数时表示以毫秒为单位的超时时间。

--- a/client/session.go
+++ b/client/session.go
@@ -81,7 +81,7 @@ func (s *Session) Open(enableRPCCompression bool, connectionTimeoutInMs int) err
 
 	// in thrift 0.14.1, this func returns two values; in thrift 0.15.0, it returns one.
 	s.trans = thrift.NewTSocketConf(net.JoinHostPort(s.config.Host, s.config.Port), &thrift.TConfiguration{
-		ConnectTimeout: time.Duration(connectionTimeoutInMs), // Use 0 for no timeout
+		ConnectTimeout: time.Duration(connectionTimeoutInMs) * time.Millisecond, // Use 0 for no timeout
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
The implementation of the function ```client/session.go/Open()``` is mismatched with the description.
The parameter `connectionTimeoutInMs` represents connection timeout in milliseconds.
However, in the older version, this function did not implement correctly, regarding it as nanosecond instead.
The bug is now fixed.
Positive value of this parameter means connection timeout in milliseconds.
Set 0 for no timeout.