### PR TITLE
set DefaultTimeZone if GetTimeZone returns an error

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -406,7 +406,7 @@ func (s *Session) InsertStringRecord(deviceId string, measurements []string, val
 func (s *Session) GetTimeZone() (string, error) {
 	resp, err := s.client.GetTimeZone(context.Background(), s.sessionId)
 	if err != nil {
-		return "", err
+		return DefaultTimeZone, err
 	}
 	return resp.TimeZone, nil
 }

--- a/example/session_example.go
+++ b/example/session_example.go
@@ -102,8 +102,10 @@ func main() {
 	deleteData()
 
 	setTimeZone()
-	if tz, err := getTimeZone(); err != nil {
-		fmt.Printf("TimeZone: %s", tz)
+	if tz, err := getTimeZone(); err == nil {
+		fmt.Printf("TimeZone: %s\n", tz)
+	} else {
+		fmt.Printf("getTimeZone ERROR: %v\n", err)
 	}
 
 	executeStatement()


### PR DESCRIPTION
`func (s *Session) GetTimeZone() (string, error)`:
`return "", err`  -->   `return DefaultTimeZone, err`

1. If the error is not handled, the TimeZone in the config may be directly set to an empty string value without any check.
2. In previous file 'session_example.go', the time zone was printed only when there was an error. It should be a design error