### PR TITLE
[To rel/0.13] Fix some bugs about time zone

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -405,7 +405,7 @@ func (s *Session) InsertStringRecord(deviceId string, measurements []string, val
 func (s *Session) GetTimeZone() (string, error) {
 	resp, err := s.client.GetTimeZone(context.Background(), s.sessionId)
 	if err != nil {
-		return "", err
+		return DefaultTimeZone, err
 	}
 	return resp.TimeZone, nil
 }

--- a/client/session.go
+++ b/client/session.go
@@ -108,12 +108,7 @@ func (s *Session) Open(enableRPCCompression bool, connectionTimeoutInMs int) err
 	}
 	s.sessionId = resp.GetSessionId()
 	s.requestStatementId, err = s.client.RequestStatementId(context.Background(), s.sessionId)
-	if err != nil {
-		return err
-	}
 
-	s.SetTimeZone(s.config.TimeZone)
-	s.config.TimeZone, err = s.GetTimeZone()
 	return err
 }
 
@@ -154,19 +149,14 @@ func (s *Session) OpenCluster(enableRPCCompression bool) error {
 	s.client = rpc.NewTSIServiceClient(thrift.NewTStandardClient(iprot, oprot))
 	req := rpc.TSOpenSessionReq{ClientProtocol: rpc.TSProtocolVersion_IOTDB_SERVICE_PROTOCOL_V3, ZoneId: s.config.TimeZone, Username: &s.config.UserName,
 		Password: &s.config.Password}
-	fmt.Println(req)
+
 	resp, err := s.client.OpenSession(context.Background(), &req)
 	if err != nil {
 		return err
 	}
 	s.sessionId = resp.GetSessionId()
 	s.requestStatementId, err = s.client.RequestStatementId(context.Background(), s.sessionId)
-	if err != nil {
-		return err
-	}
 
-	s.SetTimeZone(s.config.TimeZone)
-	s.config.TimeZone, err = s.GetTimeZone()
 	return err
 }
 
@@ -1025,8 +1015,15 @@ func (s *Session) initClusterConn(node endPoint) error {
 			}
 		}
 	}
-	var protocolFactory thrift.TProtocolFactory
-	protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
+
+	if s.config.FetchSize <= 0 {
+		s.config.FetchSize = DefaultFetchSize
+	}
+	if s.config.TimeZone == "" {
+		s.config.TimeZone = DefaultTimeZone
+	}
+
+	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
 	iprot := protocolFactory.GetProtocol(s.trans)
 	oprot := protocolFactory.GetProtocol(s.trans)
 	s.client = rpc.NewTSIServiceClient(thrift.NewTStandardClient(iprot, oprot))
@@ -1039,12 +1036,7 @@ func (s *Session) initClusterConn(node endPoint) error {
 	}
 	s.sessionId = resp.GetSessionId()
 	s.requestStatementId, err = s.client.RequestStatementId(context.Background(), s.sessionId)
-	if err != nil {
-		return err
-	}
 
-	s.SetTimeZone(s.config.TimeZone)
-	s.config.TimeZone, err = s.GetTimeZone()
 	return err
 
 }

--- a/example/session_example.go
+++ b/example/session_example.go
@@ -99,8 +99,10 @@ func main() {
 	deleteData()
 
 	setTimeZone()
-	if tz, err := getTimeZone(); err != nil {
-		fmt.Printf("TimeZone: %s", tz)
+	if tz, err := getTimeZone(); err == nil {
+		fmt.Printf("TimeZone: %s\n", tz)
+	} else {
+		fmt.Printf("getTimeZone ERROR: %v\n", err)
 	}
 
 	executeStatement()


### PR DESCRIPTION
Fix some bugs about time zone.
This PR is for `rel/0.13`, relative PR for `main`:
1. https://github.com/apache/iotdb-client-go/pull/68 
2. https://github.com/apache/iotdb-client-go/pull/69

### summary:
#### cleanup invalid codes from session
cleanup invalid codes from session

#### set DefaultTimeZone if GetTimeZone returns an error
`func (s *Session) GetTimeZone() (string, error)`:
`return "", err` --> `return DefaultTimeZone, err`

If the error is not handled, the TimeZone in the config may be directly set to an empty string value without any check.
In previous file 'session_example.go', the time zone was printed only when there was an error. It should be a design error


