### PR TITLE
[To rel/0.13] add ConnectRetryMax for config; fix typo of "UNKONW"

### DIFF
--- a/client/protocol.go
+++ b/client/protocol.go
@@ -26,7 +26,7 @@ type TSEncoding uint8
 type TSCompressionType uint8
 
 const (
-	UNKNOW  TSDataType = -1
+	UNKNOWN TSDataType = -1
 	BOOLEAN TSDataType = 0
 	INT32   TSDataType = 1
 	INT64   TSDataType = 2

--- a/client/rpcdataset.go
+++ b/client/rpcdataset.go
@@ -79,7 +79,7 @@ func (s *IoTDBRpcDataSet) getColumnIndex(columnName string) int32 {
 
 func (s *IoTDBRpcDataSet) getColumnType(columnName string) TSDataType {
 	if s.closed {
-		return UNKNOW
+		return UNKNOWN
 	}
 	return s.columnTypeDeduplicatedList[s.getColumnIndex(columnName)]
 }

--- a/client/rpcdataset_test.go
+++ b/client/rpcdataset_test.go
@@ -76,7 +76,7 @@ func TestIoTDBRpcDataSet_getColumnType(t *testing.T) {
 			args: args{
 				columnName: "root.ln.device1.tick_count",
 			},
-			want: UNKNOW,
+			want: UNKNOWN,
 		},
 	}
 	for _, tt := range tests {

--- a/client/session.go
+++ b/client/session.go
@@ -38,19 +38,21 @@ import (
 )
 
 const (
-	DefaultTimeZone  = "Asia/Shanghai"
-	DefaultFetchSize = 1024
+	DefaultTimeZone        = "Asia/Shanghai"
+	DefaultFetchSize       = 1024
+	DefaultConnectRetryMax = 3
 )
 
 var errLength = errors.New("deviceIds, times, measurementsList and valuesList's size should be equal")
 
 type Config struct {
-	Host      string
-	Port      string
-	UserName  string
-	Password  string
-	FetchSize int32
-	TimeZone  string
+	Host            string
+	Port            string
+	UserName        string
+	Password        string
+	FetchSize       int32
+	TimeZone        string
+	ConnectRetryMax int
 }
 
 type Session struct {
@@ -74,6 +76,9 @@ func (s *Session) Open(enableRPCCompression bool, connectionTimeoutInMs int) err
 	}
 	if s.config.TimeZone == "" {
 		s.config.TimeZone = DefaultTimeZone
+	}
+	if s.config.ConnectRetryMax <= 0 {
+		s.config.ConnectRetryMax = DefaultConnectRetryMax
 	}
 
 	var protocolFactory thrift.TProtocolFactory
@@ -134,6 +139,9 @@ func (s *Session) OpenCluster(enableRPCCompression bool) error {
 	}
 	if s.config.TimeZone == "" {
 		s.config.TimeZone = DefaultTimeZone
+	}
+	if s.config.ConnectRetryMax <= 0 {
+		s.config.ConnectRetryMax = DefaultConnectRetryMax
 	}
 
 	var protocolFactory thrift.TProtocolFactory
@@ -1022,6 +1030,9 @@ func (s *Session) initClusterConn(node endPoint) error {
 	if s.config.TimeZone == "" {
 		s.config.TimeZone = DefaultTimeZone
 	}
+	if s.config.ConnectRetryMax <= 0 {
+		s.config.ConnectRetryMax = DefaultConnectRetryMax
+	}
 
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
 	iprot := protocolFactory.GetProtocol(s.trans)
@@ -1056,7 +1067,7 @@ func (s *Session) reconnect() bool {
 	var err error
 	var connectedSuccess = false
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < s.config.ConnectRetryMax; i++ {
 		for e := endPointList.Front(); e != nil; e = e.Next() {
 			err = s.initClusterConn(e.Value.(endPoint))
 			if err == nil {


### PR DESCRIPTION
1. add ConnectRetryMax for config
2. fix typo of "UNKONW" --> "UNKONWN"
3. same as this PR: https://github.com/apache/iotdb-client-go/pull/65 , but this is for rel/0.13