### PR TITLE
Fix off-by-one bounds check in Tablet.SetValueAt/GetValueAt

### DIFF
--- a/client/tablet.go
+++ b/client/tablet.go
@@ -110,11 +110,11 @@ func (t *Tablet) SetTimestamp(timestamp int64, rowIndex int) {
 
 func (t *Tablet) SetValueAt(value interface{}, columnIndex, rowIndex int) error {
 
-	if columnIndex < 0 || columnIndex > len(t.measurementSchemas) {
+	if columnIndex < 0 || columnIndex >= len(t.measurementSchemas) {
 		return fmt.Errorf("illegal argument columnIndex %d", columnIndex)
 	}
 
-	if rowIndex < 0 || rowIndex > t.maxRowNumber {
+	if rowIndex < 0 || rowIndex >= t.maxRowNumber {
 		return fmt.Errorf("illegal argument rowIndex %d", rowIndex)
 	}
 
@@ -221,11 +221,11 @@ func (t *Tablet) GetMaxRowNumber() int {
 }
 
 func (t *Tablet) GetValueAt(columnIndex, rowIndex int) (interface{}, error) {
-	if columnIndex < 0 || columnIndex > len(t.measurementSchemas) {
+	if columnIndex < 0 || columnIndex >= len(t.measurementSchemas) {
 		return nil, fmt.Errorf("illegal argument columnIndex %d", columnIndex)
 	}
 
-	if rowIndex < 0 || rowIndex > t.maxRowNumber {
+	if rowIndex < 0 || rowIndex >= t.maxRowNumber {
 		return nil, fmt.Errorf("illegal argument rowIndex %d", rowIndex)
 	}
 

--- a/client/tablet_test.go
+++ b/client/tablet_test.go
@@ -225,6 +225,22 @@ func TestTablet_SetValueAt(t *testing.T) {
 			},
 			wantErr: true,
 		}, {
+			name: "columnIndex-out-of-range-boundary",
+			args: args{
+				value:       0,
+				columnIndex: 10,
+				rowIndex:    0,
+			},
+			wantErr: true,
+		}, {
+			name: "rowIndex-out-of-range-boundary",
+			args: args{
+				value:       0,
+				columnIndex: 0,
+				rowIndex:    1,
+			},
+			wantErr: true,
+		}, {
 			name: "restart_count",
 			args: args{
 				value:       int32(0),
@@ -410,6 +426,20 @@ func TestTablet_GetValueAt(t *testing.T) {
 			},
 			want:    int64(1608268702780),
 			wantErr: false,
+		}, {
+			name: "columnIndex-out-of-range-boundary",
+			args: args{
+				columnIndex: 10,
+				rowIndex:    0,
+			},
+			wantErr: true,
+		}, {
+			name: "rowIndex-out-of-range-boundary",
+			args: args{
+				columnIndex: 0,
+				rowIndex:    1,
+			},
+			wantErr: true,
 		},
 	}
 	if tablet, err := createTablet(1); err == nil {


### PR DESCRIPTION
### What
Fix an off-by-one in the index bounds checks of `Tablet.SetValueAt` and `Tablet.GetValueAt`.

### Problem
Both methods validate `columnIndex`/`rowIndex` before indexing the schema/value slices and return an `illegal argument` error for out-of-range indices. The guards used `columnIndex > len(t.measurementSchemas)` and `rowIndex > t.maxRowNumber`. Since `measurementSchemas`/`values` have length N and each value slice + `timestamps` are `make([]T, maxRowNumber)` (see `NewTablet`), the valid ranges are `0..N-1` and `0..maxRowNumber-1`. Using `>` lets the exact boundary index (`== len`, `== maxRowNumber`) escape the guard, after which `measurementSchemas[N]` / `values[...][maxRowNumber]` panics with `index out of range` instead of returning the intended error. (The existing out-of-range tests use `65535`, far past the boundary, so never exercised it.)

### Fix
Change all four guards from `>` to `>=`.

### Tests
Added exact-boundary regression cases (`columnIndex == len`, `rowIndex == maxRowNumber`, `wantErr: true`) to `TestTablet_SetValueAt` / `GetValueAt`; they panic before the fix and return an error after. `go test ./client/` passes; `gofmt`/`vet` clean.
