### PR TITLE
Add Tablet.SetTimestampAt with rowIndex validation

### DIFF
--- a/client/tablet.go
+++ b/client/tablet.go
@@ -108,6 +108,19 @@ func (t *Tablet) SetTimestamp(timestamp int64, rowIndex int) {
 	t.timestamps[rowIndex] = timestamp
 }
 
+// SetTimestampAt is a bounds-checked alternative to SetTimestamp. It validates
+// rowIndex and returns an "illegal argument rowIndex" error instead of
+// panicking with an index-out-of-range when rowIndex is negative or beyond the
+// tablet's capacity, consistent with SetValueAt and GetValueAt. The existing
+// SetTimestamp is preserved unchanged for source compatibility.
+func (t *Tablet) SetTimestampAt(timestamp int64, rowIndex int) error {
+	if rowIndex < 0 || rowIndex >= t.maxRowNumber {
+		return fmt.Errorf("illegal argument rowIndex %d", rowIndex)
+	}
+	t.timestamps[rowIndex] = timestamp
+	return nil
+}
+
 func (t *Tablet) SetValueAt(value interface{}, columnIndex, rowIndex int) error {
 
 	if columnIndex < 0 || columnIndex >= len(t.measurementSchemas) {

--- a/client/tablet_test.go
+++ b/client/tablet_test.go
@@ -173,6 +173,24 @@ func TestTablet_SetTimestamp(t *testing.T) {
 	}
 }
 
+func TestTablet_SetTimestampAtRowIndexBounds(t *testing.T) {
+	tablet, err := createTablet(1) // maxRowNumber == 1, so only row index 0 is valid
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A valid row index returns no error.
+	if err := tablet.SetTimestampAt(1608268702769, 0); err != nil {
+		t.Errorf("SetTimestampAt(_, 0) on a 1-row tablet returned error: %v", err)
+	}
+	// Out-of-range row indices return an error instead of panicking with an
+	// index-out-of-range, matching SetValueAt/GetValueAt.
+	for _, rowIndex := range []int{1, -1} {
+		if err := tablet.SetTimestampAt(1, rowIndex); err == nil {
+			t.Errorf("SetTimestampAt(_, %d) on a 1-row tablet should return an error, got nil", rowIndex)
+		}
+	}
+}
+
 func TestTablet_SetValueAt(t *testing.T) {
 	type args struct {
 		value       interface{}


### PR DESCRIPTION
## Problem

`Tablet.SetTimestamp` writes to `t.timestamps[rowIndex]` without validating
`rowIndex`, so an out-of-range row panics with an index-out-of-range error
instead of returning one. For example, with a tablet created via
`NewTablet(..., 1)` (only row index 0 is valid), `SetTimestamp(ts, 1)` panics.

## Fix

As @HTHou noted, adding an `error` return to `SetTimestamp` would break source
compatibility for consumers relying on its signature (interface satisfaction,
method values), and this module already has v2 releases. So `SetTimestamp` is
left unchanged, and a checked alternative is added:

```go
func (t *Tablet) SetTimestampAt(timestamp int64, rowIndex int) error {
	if rowIndex < 0 || rowIndex >= t.maxRowNumber {
		return fmt.Errorf("illegal argument rowIndex %d", rowIndex)
	}
	t.timestamps[rowIndex] = timestamp
	return nil
}
```

`SetTimestampAt` mirrors the bounds handling of `SetValueAt` / `GetValueAt`,
returning an `illegal argument rowIndex` error for a negative or out-of-range
row. The PR is purely additive; `SetTimestamp` can be deprecated in
documentation later if callers should migrate to the checked API.

## Tests

Added `TestTablet_SetTimestampAtRowIndexBounds`: a valid row index returns no
error; out-of-range indices (1 on a one-row tablet, and -1) return an error
instead of panicking. `go build ./...` and `go test ./client/` pass.

Follow-up to #168.
